### PR TITLE
fix: consistency for `const`, `export` and `param` aliases

### DIFF
--- a/src/noRedundantJsdocAnnotationsRule.ts
+++ b/src/noRedundantJsdocAnnotationsRule.ts
@@ -51,7 +51,7 @@ const JSDOC_TAGS_BLACKLIST = new Set([
  * A list of JSDoc @tags that may include a {type} declaration.
  * These will only be banned when that type is passed.
  */
-const JSDOC_TAGS_WITH_TYPES = new Set(['param', 'return', 'returns']);
+const JSDOC_TAGS_WITH_TYPES = new Set(['arg', 'argument', 'param', 'return', 'returns']);
 
 export class Rule extends Lint.Rules.AbstractRule {
   public static metadata: Lint.IRuleMetadata = {

--- a/src/noRedundantJsdocAnnotationsRule.ts
+++ b/src/noRedundantJsdocAnnotationsRule.ts
@@ -10,11 +10,13 @@ const JSDOC_TAGS_BLACKLIST = new Set([
   'access',
   'augments',
   'class',
+  'const',
   'constant',
   'constructor',
   'constructs',
   'default',
   'enum',
+  'export',
   'exports',
   'extends',
   'function',
@@ -49,7 +51,7 @@ const JSDOC_TAGS_BLACKLIST = new Set([
  * A list of JSDoc @tags that may include a {type} declaration.
  * These will only be banned when that type is passed.
  */
-const JSDOC_TAGS_WITH_TYPES = new Set(['const', 'export', 'param', 'return', 'returns']);
+const JSDOC_TAGS_WITH_TYPES = new Set(['param', 'return', 'returns']);
 
 export class Rule extends Lint.Rules.AbstractRule {
   public static metadata: Lint.IRuleMetadata = {


### PR DESCRIPTION
Summary of what happened:

- Be consistent with linting for `const`/`constant` & `export`/`exports`
  Although in JSDoc constants and exports can have a type, in Typescript that's redundant.
  Ultimately constants and exports are described in a different manner in Typescript because of module patterns.

- Add aliases for `@param`: `@arg` and `@argument`